### PR TITLE
PartialEq and Eq derives, host trait changes

### DIFF
--- a/src/consensus_client.rs
+++ b/src/consensus_client.rs
@@ -8,26 +8,26 @@ pub type ConsensusClientId = u64;
 pub const ETHEREUM_CONSENSUS_CLIENT_ID: ConsensusClientId = 100;
 pub const GNOSIS_CONSENSUS_CLIENT_ID: ConsensusClientId = 200;
 
-#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo, PartialEq, Eq)]
 pub struct StateCommitment {
     /// Timestamp in nanoseconds
     pub timestamp: u64,
     pub commitment_root: Vec<u8>,
 }
 
-#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo, PartialEq, Eq)]
 pub struct IntermediateState {
     pub height: StateMachineHeight,
     pub commitment: StateCommitment,
 }
 
-#[derive(Debug, Clone, Copy, Encode, Decode, scale_info::TypeInfo)]
+#[derive(Debug, Clone, Copy, Encode, Decode, scale_info::TypeInfo, PartialEq, Eq)]
 pub struct StateMachineId {
     pub state_id: u64,
     pub consensus_client: ConsensusClientId,
 }
 
-#[derive(Debug, Clone, Copy, Encode, Decode, scale_info::TypeInfo)]
+#[derive(Debug, Clone, Copy, Encode, Decode, scale_info::TypeInfo, PartialEq, Eq)]
 pub struct StateMachineHeight {
     pub id: StateMachineId,
     pub height: u64,

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -25,8 +25,8 @@ fn verify_delay_passed(
     host: &dyn ISMPHost,
     proof_height: StateMachineHeight,
 ) -> Result<bool, Error> {
-    let update_time = host.state_machine_update_time(proof_height)?;
-    let delay_period = host.delay_period(proof_height.id);
+    let update_time = host.consensus_update_time(proof_height.id.consensus_client)?;
+    let delay_period = host.delay_period(proof_height.id.consensus_client);
     let current_timestamp = host.host_timestamp();
     Ok(current_timestamp - update_time > delay_period)
 }

--- a/src/handlers/req_res.rs
+++ b/src/handlers/req_res.rs
@@ -35,7 +35,7 @@ fn validate_state_machine(
     if !verify_delay_passed(host, proof.height)? {
         return Err(Error::DelayNotElapsed {
             current_time: host.host_timestamp(),
-            update_time: host.state_machine_update_time(proof.height)?,
+            update_time: host.consensus_update_time(proof.height.id.consensus_client)?,
         });
     }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -44,8 +44,6 @@ pub trait ISMPHost {
     ) -> Result<StateCommitment, Error>;
     /// Returns the host timestamp when this consensus client was last updated
     fn consensus_update_time(&self, id: ConsensusClientId) -> Result<Duration, Error>;
-    /// Returns the host timestamp when this consensus client was updated
-    fn state_machine_update_time(&self, height: StateMachineHeight) -> Result<Duration, Error>;
     /// Returns the scale encoded consensus state for a consensus client
     fn consensus_state(&self, id: ConsensusClientId) -> Result<Vec<u8>, Error>;
     /// Return the host timestamp in nanoseconds
@@ -63,12 +61,6 @@ pub trait ISMPHost {
     fn store_consensus_update_time(
         &self,
         id: ConsensusClientId,
-        timestamp: Duration,
-    ) -> Result<(), Error>;
-    /// Store the timestamp when the state machine was updated
-    fn store_state_machine_update_time(
-        &self,
-        height: StateMachineHeight,
         timestamp: Duration,
     ) -> Result<(), Error>;
     /// Store the timestamp when the state machine was updated
@@ -111,8 +103,8 @@ pub trait ISMPHost {
     /// Returns a keccak256 hash of a byte slice
     fn keccak256(&self, bytes: &[u8]) -> [u8; 32];
 
-    /// Returns the configured delay period for a state machine
-    fn delay_period(&self, id: StateMachineId) -> Duration;
+    /// Returns the configured delay period for a consensus client
+    fn delay_period(&self, id: ConsensusClientId) -> Duration;
 
     /// Return a handle to the router
     fn ismp_router(&self) -> Box<dyn IISMPRouter>;

--- a/src/messaging.rs
+++ b/src/messaging.rs
@@ -3,14 +3,14 @@ use crate::router::{Request, Response};
 use alloc::vec::Vec;
 use codec::{Decode, Encode};
 
-#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo, PartialEq, Eq)]
 pub struct ConsensusMessage {
     /// Scale Encoded Consensus Proof
     pub consensus_proof: Vec<u8>,
     /// Consensus client id
     pub consensus_client_id: ConsensusClientId,
 }
-#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo, PartialEq, Eq)]
 pub struct CreateConsensusClient {
     /// Scale encoded consensus state
     pub consensus_state: Vec<u8>,
@@ -18,7 +18,7 @@ pub struct CreateConsensusClient {
     pub consensus_client_id: ConsensusClientId,
 }
 
-#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo, PartialEq, Eq)]
 pub struct RequestMessage {
     /// Request from source chain
     pub request: Request,
@@ -26,7 +26,7 @@ pub struct RequestMessage {
     pub proof: Proof,
 }
 
-#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo, PartialEq, Eq)]
 pub struct ResponseMessage {
     /// Response from sink chain
     pub response: Response,
@@ -34,7 +34,7 @@ pub struct ResponseMessage {
     pub proof: Proof,
 }
 
-#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo, PartialEq, Eq)]
 pub struct Proof {
     /// State machine height
     pub height: StateMachineHeight,
@@ -42,7 +42,7 @@ pub struct Proof {
     pub proof: Vec<Vec<u8>>,
 }
 
-#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo)]
+#[derive(Debug, Clone, Encode, Decode, scale_info::TypeInfo, PartialEq, Eq)]
 pub enum Message {
     #[codec(index = 0)]
     CreateConsensusClient(CreateConsensusClient),

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -1,7 +1,7 @@
 use crate::host::ChainID;
 use derive_more::Display;
 
-#[derive(Clone, Debug, Display)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(
     fmt = "acknowledgements/{}-{}/{}",
     "source_chain",
@@ -14,7 +14,7 @@ pub struct AckPath {
     pub nonce: u64,
 }
 
-#[derive(Clone, Debug, Display)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "requests/{}-{}/{}", "source_chain", "dest_chain", "nonce")]
 pub struct RequestPath {
     pub dest_chain: ChainID,
@@ -22,7 +22,7 @@ pub struct RequestPath {
     pub nonce: u64,
 }
 
-#[derive(Clone, Debug, Display)]
+#[derive(Clone, Debug, Display, PartialEq, Eq)]
 #[display(fmt = "responses/{}-{}/{}", "source_chain", "dest_chain", "nonce")]
 pub struct ResponsePath {
     pub dest_chain: ChainID,


### PR DESCRIPTION
Adds `PartialEq` and `Eq` derives where possible.
Modify logic around delay checking to focus on consensus clients.