### PR TITLE
State machine height update time

### DIFF
--- a/ismp-testsuite/src/lib.rs
+++ b/ismp-testsuite/src/lib.rs
@@ -77,7 +77,7 @@ pub fn check_challenge_period<H: IsmpHost>(host: &H) -> Result<(), &'static str>
     let challenge_period = host.challenge_period(mock_consensus_state_id()).unwrap();
     let previous_update_time = host.timestamp() - (challenge_period / 2);
     host.store_consensus_update_time(mock_consensus_state_id(), previous_update_time).unwrap();
-
+    host.store_state_machine_update_time(intermediate_state.height, previous_update_time).unwrap();
     let res = handle_incoming_message::<H>(host, consensus_message);
     assert!(matches!(res, Err(ismp::error::Error::ChallengePeriodNotElapsed { .. })));
 
@@ -147,7 +147,7 @@ pub fn frozen_check<H: IsmpHost>(host: &H) -> Result<(), &'static str> {
     let challenge_period = host.challenge_period(mock_consensus_state_id()).unwrap();
     let previous_update_time = host.timestamp() - (challenge_period * 2);
     host.store_consensus_update_time(mock_consensus_state_id(), previous_update_time).unwrap();
-
+    host.store_state_machine_update_time(intermediate_state.height, previous_update_time).unwrap();
     let frozen_height = StateMachineHeight {
         id: intermediate_state.height.id,
         height: intermediate_state.height.height - 1,
@@ -205,6 +205,7 @@ pub fn timeout_post_processing_check<H: IsmpHost>(
     let challenge_period = host.challenge_period(mock_consensus_state_id()).unwrap();
     let previous_update_time = host.timestamp() - (challenge_period * 2);
     host.store_consensus_update_time(mock_consensus_state_id(), previous_update_time).unwrap();
+    host.store_state_machine_update_time(intermediate_state.height, previous_update_time).unwrap();
     let dispatch_post = DispatchPost {
         dest: StateMachine::Kusama(2000),
         from: vec![0u8; 32],

--- a/ismp-testsuite/src/mocks.rs
+++ b/ismp-testsuite/src/mocks.rs
@@ -132,6 +132,17 @@ impl IsmpHost for Host {
             .ok_or_else(|| Error::ImplementationSpecific("Consensus update time not found".into()))
     }
 
+    fn state_machine_update_time(
+        &self,
+        state_machine_height: StateMachineHeight,
+    ) -> Result<Duration, Error> {
+        self.consensus_update_time
+            .borrow()
+            .get(&state_machine_height.id.consensus_state_id)
+            .copied()
+            .ok_or_else(|| Error::ImplementationSpecific("Consensus update time not found".into()))
+    }
+
     fn consensus_client_id(
         &self,
         consensus_state_id: ConsensusStateId,
@@ -221,6 +232,14 @@ impl IsmpHost for Host {
         timestamp: Duration,
     ) -> Result<(), Error> {
         self.consensus_update_time.borrow_mut().insert(id, timestamp);
+        Ok(())
+    }
+
+    fn store_state_machine_update_time(
+        &self,
+        _state_machine_height: StateMachineHeight,
+        _timestamp: Duration,
+    ) -> Result<(), Error> {
         Ok(())
     }
 

--- a/ismp/src/handlers.rs
+++ b/ismp/src/handlers.rs
@@ -84,7 +84,7 @@ fn verify_delay_passed<H>(host: &H, proof_height: &StateMachineHeight) -> Result
 where
     H: IsmpHost,
 {
-    let update_time = host.consensus_update_time(proof_height.id.consensus_state_id)?;
+    let update_time = host.state_machine_update_time(*proof_height)?;
     let delay_period = host.challenge_period(proof_height.id.consensus_state_id).ok_or(
         Error::ChallengePeriodNotConfigured {
             consensus_state_id: proof_height.id.consensus_state_id,
@@ -123,7 +123,7 @@ where
         return Err(Error::ChallengePeriodNotElapsed {
             consensus_state_id: proof_height.id.consensus_state_id,
             current_time: host.timestamp(),
-            update_time: host.consensus_update_time(proof_height.id.consensus_state_id)?,
+            update_time: host.state_machine_update_time(proof_height)?,
         })
     }
 

--- a/ismp/src/handlers/consensus.rs
+++ b/ismp/src/handlers/consensus.rs
@@ -85,6 +85,7 @@ where
             }
 
             host.store_state_machine_commitment(state_height, commitment_height.commitment)?;
+            host.store_state_machine_update_time(state_height, host.timestamp())?;
         }
 
         if let Some(latest_height) = commitment_heights.last() {
@@ -125,10 +126,11 @@ where
     host.store_challenge_period(message.consensus_state_id, message.challenge_period)?;
     host.store_consensus_state_id(message.consensus_state_id, message.consensus_client_id)?;
 
-    // Store all intermedite state machine commitments
+    // Store all intermediate state machine commitments
     for (id, state_commitment) in message.state_machine_commitments {
         let height = StateMachineHeight { id, height: state_commitment.height };
         host.store_state_machine_commitment(height, state_commitment.commitment)?;
+        host.store_state_machine_update_time(height, host.timestamp())?;
         host.store_latest_commitment_height(height)?;
     }
 

--- a/ismp/src/host.rs
+++ b/ismp/src/host.rs
@@ -55,6 +55,12 @@ pub trait IsmpHost: Keccak256 {
         consensus_state_id: ConsensusStateId,
     ) -> Result<Duration, Error>;
 
+    /// Should return the host timestamp when this state machine height was committed
+    fn state_machine_update_time(
+        &self,
+        state_machine_height: StateMachineHeight,
+    ) -> Result<Duration, Error>;
+
     /// Should return the registered consensus client id for this consensus state id
     fn consensus_client_id(
         &self,
@@ -113,6 +119,13 @@ pub trait IsmpHost: Keccak256 {
     fn store_consensus_update_time(
         &self,
         consensus_state_id: ConsensusStateId,
+        timestamp: Duration,
+    ) -> Result<(), Error>;
+
+    /// Store the timestamp when the state machine height was committed
+    fn store_state_machine_update_time(
+        &self,
+        state_machine_height: StateMachineHeight,
         timestamp: Duration,
     ) -> Result<(), Error>;
 


### PR DESCRIPTION
Ran into an an issue because of this when testing the grandpa client with the relayer.
We need a separate storage item for tracking state machine height update times.
Because consensus update time gets overwritten any time a new update arrives, this makes the state machine update events that would be emitted unusable since we'll be using the new consensus update time to check that the challenge period has elapsed.
Also makes sense to have them separately incase we totally decouple stage machine updates from consensus client updates sometime in the future.
